### PR TITLE
Sync missing EAFIX project knowledge files

### DIFF
--- a/EAFIX_auth_docs/Q-R_atonic to canonical crosswalk.txt
+++ b/EAFIX_auth_docs/Q-R_atonic to canonical crosswalk.txt
@@ -1,0 +1,39 @@
+I want to explore deeper into this, and how and why there is such a large variance between the number of steps :
+
+Two lifecycle models with no crosswalk.
+EAFIX_ATONIC…md describes 11 phases / 71 atomic steps; the canonical JSON is 10 phases / 26 steps. They’re not just different granularity — they differ in scope. The ATONIC version omits config/scheduling (PHASE_A), the bars→indicators→feature decomposition (PHASE_C/D), and orchestration+health (PHASE_J); it splits re-entry into three phases and adds explicit transport and result-capture phases. The routing file says the JSON wins on conflict, but there is no 71→26 mapping table, so nothing actually reconciles the narrative steps to canonical step IDs
+
+——
+
+I’ll dig into the actual source documents to understand the structure of both models and why they diverge so much. Let me read them directly.
+
+Let me see the middle section of the ATONIC document that was truncated.
+
+Now let me read the canonical JSON model and the routing/standards registry.
+
+Let me read the middle steps of the canonical JSON (steps 5–18).
+
+Let me check the standards registry for the routing/conflict rules and the step catalog.
+
+I’ve now read both models end to end, plus the standards registry that governs which one wins. Here’s what’s actually driving the 71-vs-26 gap — it’s deeper than granularity, and you’re right that nothing reconciles them today.
+
+1. They decompose along different axes. The canonical JSON’s unit of a “step” is one module emitting one contract — every step carries a module_id, input_contracts, output_contracts, and dependency_step_ids. It’s an architecture/data-flow decomposition: a dependency DAG of services. The ATONIC markdown’s unit is one operation — function-call granularity (calendar_service.py::parse_raw_calendar, ::normalize_events, ::assign_cal8). It’s a procedural runbook. So one canonical module routinely explodes into 2–5 ATONIC operations. Canonical S04 “Normalize raw calendar entries” (the single module D3_CALENDAR_NORMALIZER) becomes ATONIC steps 3+4+5 (parse, normalize, CAL8 assign). That ratio alone gets you most of the way to 2.7×.
+
+2. The variance is concentrated in re-entry, via loop-unrolling. Canonical handles all of re-entry in steps 19–24 plus one orchestration step, S25, which literally says the reentry intent “follows same risk→order→route→transport→execute chain.” It treats re-entry as a reference back to the existing path. ATONIC instead physically re-instantiates the whole downstream chain: Phases 9, 10, and 11 (steps 51–71), where steps 61–67 are explicitly annotated “same as Steps 21–37.” That’s ~21 ATONIC steps standing in for ~7 canonical ones. The narrative unrolls the loop; the canonical model keeps it as a loop.
+
+3. It is not a superset relationship — the scope gap runs both ways. This is the part that makes a clean crosswalk impossible:
+
+	•	Canonical has, ATONIC omits: config snapshot (S01), scheduler tick (S02), bars (S08), indicators (S09), feature frame (S10), broker-event normalization as its own step (S18), OMS state machine (S19), orchestration + health/SLO (S25–S26). ATONIC collapses the entire market-data pipeline into one line — “Step 14: Market State Acquisition” / get_current_state — and never models bars or indicators at all.
+	•	ATONIC has, canonical omits: transport mechanics — hash files, sequence numbers, heartbeats, lock detection (steps 28–31); EA-internal error classification and retry/abort (36–37); result hashing (44); loop-prevention counter (68). The canonical model deliberately abstracts all of these inside validation contracts — e.g. S16’s rule “atomic write+rename; sequence + hash; idempotent resend” swallows ATONIC’s four separate transport steps.
+
+So a 71→26 map has three relationship types, not one: canonical-step → span-of-ATONIC-steps (1:many), ATONIC-step → nothing (mechanics the contracts hide), and canonical-step → nothing (lifecycle stages the runbook skips).
+
+4. They serve different readers, which is why both were allowed to exist. The JSON is machine-facing (step_ids, dependency DAG, real entrypoint_files like services\reentry-matrix-svc\...) — built to validate against the modular repo. The ATONIC doc is a human operational playbook organized by time/narrative, with prose failure handling and a state-transition map.
+
+On authority: the registry confirms your routing read and sharpens it. process_step_catalog.json (26 steps) is tagged candidate_structured_reference — the top tier present — and updated_trading_process_aligned.json is generated from it (reconciled-from-process-step-catalog/1.0). <cite index="">The ATONIC markdown isn’t in the source_file_index at all</cite> — it’s not ranked as authority in any tier. And <cite index="">authority_policy says legacy files are non-authoritative, conflicting legacy rules are superseded, and a rule is only blocking once it has an enforcement gate with pass/fail criteria and evidence.</cite> So “JSON wins” is correct, but the real exposure is that the 71 narrative steps have zero traceability into the 26 canonical step_codes — so the runbook can drift from the contracts silently, and neither doc’s “full replay” claim can be cross-validated against the other.
+
+Since the missing artifact is exactly the thing you named, I built it. Here’s the full bidirectional crosswalk:
+
+All 71 ATONIC steps are now accounted for — 70 map onto canonical spans, and step 68 (the loop-prevention counter) is the lone ATONIC-only operation, which the canonical model absorbs into S25’s chain-depth/velocity validation.
+
+The crosswalk surfaces the headline number: of the 26 canonical steps, 6 are CANONICAL_ONLY (S01, S02, S08, S09, S15, S19, S26 — config, scheduling, bars, indicators, routing, OMS, health) and 13 are ONE_TO_MANY explosions. That’s the whole 71→26 story in one frame — almost none of it is true 1:1.

--- a/EAFIX_auth_docs/atonic to canonical crosswalk.csv
+++ b/EAFIX_auth_docs/atonic to canonical crosswalk.csv
@@ -1,0 +1,28 @@
+canonical_step_code,canonical_name,canonical_module_id,canonical_phase,atonic_steps,atonic_phase,relationship,notes
+S01,Resolve configuration snapshot,F1_CONFIG_PREFERENCES,PHASE_A,,,CANONICAL_ONLY,ATONIC has no config-resolution step; config assumed implicit
+S02,Emit schedule tick,F3_CLOCK_SCHEDULER,PHASE_A,,,CANONICAL_ONLY,Scheduling cadence is implicit inside ATONIC Step 2 poll_scheduler but not modeled as a step
+S03,Poll calendar source(s),D2_CALENDAR_SOURCE_ADAPTER,PHASE_B,1;2,PHASE 1,ONE_TO_MANY,ATONIC splits into source discovery (1) + polling (2)
+S04,Normalize raw calendar entries,D3_CALENDAR_NORMALIZER,PHASE_B,3;4;5,PHASE 1,ONE_TO_MANY,ATONIC splits into parse (3) + normalize (4) + CAL8 assignment (5)
+S05,Persist calendar events (append-only),F2_EVENT_LOG,PHASE_B,6;7;8,PHASE 1,ONE_TO_MANY,ATONIC splits into DB registry (6) + CSV artifact (7) + signal emission (8)
+S06,Build anticipation triggers,D4_CALENDAR_TRIGGER_BUILDER,PHASE_B,9;10;11;12;13,PHASE 2,ONE_TO_MANY,ATONIC entire Phase 2: window calc + symbol impact + TTL + suppression + context signal
+S07,Ingest market ticks,D1_MARKET_FEED_ADAPTER,PHASE_C,14,PHASE 3,PARTIAL,ATONIC collapses feed ingest into single Step 14 Market State Acquisition
+S08,Aggregate ticks into bars,C1_BAR_BUILDER,PHASE_C,,,CANONICAL_ONLY,ATONIC never models bar construction
+S09,Compute indicators,C2_INDICATOR_ENGINE,PHASE_C,,,CANONICAL_ONLY,ATONIC never models indicator computation
+S10,Assemble strategy feature frame,C3_FEATURE_PACKAGER,PHASE_D,15,PHASE 3,PARTIAL,Loosely maps to ATONIC Step 15 Hybrid Context Construction
+S11,Generate signal (or suppression),S1_SIGNAL_ENGINE,PHASE_E,16;17;18;19;20,PHASE 3,ONE_TO_MANY,ATONIC splits into direction + signal create + schema val + dedup + registry append
+S12,Convert signal to trade intent,S2_INTENT_BUILDER,PHASE_E,,,PARTIAL,ATONIC has no distinct intent abstraction; folded into signal object
+S13,Evaluate risk and size,R1_RISK_EVALUATOR,PHASE_E,21;22;23;24;25,PHASE 4,ONE_TO_MANY,ATONIC splits into per-symbol + portfolio + circuit-breaker + idempotency + authorization
+S14,Compile order intent,R2_ORDER_INTENT_COMPILER,PHASE_F,26,PHASE 5,PARTIAL,ATONIC has no order-intent abstraction; jumps to CSV row construction (26)
+S15,Route order to broker,O1_ORDER_ROUTER,PHASE_G,,,CANONICAL_ONLY,ATONIC has no distinct routing step; folded into transport
+S16,Serialize and send to MT4 adapter,B1_MT4_ADAPTER_TRANSPORT,PHASE_G,27;28;29;30;31,PHASE 5,ONE_TO_MANY,ATONIC splits into CSV append + hash + sequence + heartbeat + lock detection
+S17,EA executes broker order,B2_MT4_EA_EXECUTOR,PHASE_G,32;33;34;35;36;37,PHASE 6,ONE_TO_MANY,ATONIC splits into preflight + validate + place + confirm + classify + retry/abort
+S18,Normalize broker events to canonical reports,B3_EXEC_EVENT_NORMALIZER,PHASE_H,38;39;42;43;44;45,PHASE 7,ONE_TO_MANY,ATONIC splits result capture: monitor + close-detect + row build + append + hash + Python poll
+S19,Apply execution reports to OMS state,O2_OMS_STATE_MACHINE,PHASE_I,,,CANONICAL_ONLY,ATONIC has no OMS state machine; close handled event-driven in EA
+S20,Classify trade close and compute canonical PnL,O3_TRADE_CLOSE_CLASSIFIER,PHASE_I,40;41;46;47;48;49;50,PHASE 7-8,ONE_TO_MANY,ATONIC splits PnL + duration + parse + WIN/LOSS + quality + integrity + registry
+S21,Bucketize outcome,E1_OUTCOME_BUCKETIZER,PHASE_I,47;50,PHASE 8,ONE_TO_MANY,Overlaps S20; ATONIC outcome classification (47) + outcome registry (50)
+S22,Compute event proximity,E2_PROXIMITY_EVALUATOR,PHASE_I,53,PHASE 9,PARTIAL,Loosely maps to ATONIC Step 53 Calendar Context Re-Validation
+S23,Lookup matrix decision,E3_MATRIX_LOOKUP,PHASE_I,52;54;55,PHASE 9,ONE_TO_MANY,ATONIC param resolution (52) + risk overlay (54) + cooldown/reentry decision (55)
+S24,Build reentry trade intent (or suppress),E4_REENTRY_INTENT_BUILDER,PHASE_I,51;56;57;58;59;60,PHASE 9-10,ONE_TO_MANY,ATONIC context reconstruct + decision record + registry + cooldown + signal gen + ledger
+S25,Loop: reentry follows same chain,F1_FLOW_ORCHESTRATOR,PHASE_J,61;62;63;64;65;66;67;69;70;71,PHASE 11,ONE_TO_MANY,Canonical keeps reentry as loop reference; ATONIC unrolls entire chain re-execution
+S26,Health aggregation + SLO evaluation,P1_HEALTH_AGGREGATOR,PHASE_J,,,CANONICAL_ONLY,ATONIC has no health/SLO aggregation step
+,,,,,Step 68,ATONIC_ONLY,Loop-prevention counter; canonical folds into S25 validation (chain depth/velocity)


### PR DESCRIPTION
## Summary

Conflict resolution for project-knowledge sync.

The original PR branch conflicted because `master` independently gained three of the five files from the original PR:

- `EAFIX_auth_docs/EAFIX module reconciliation worksheet.csv`
- `EAFIX_auth_docs/EAFIX module reconciliation worksheet.md`
- `EAFIX_auth_docs/Project knowledge summary .txt`

Resolution applied:

- Rebased the PR branch onto current `master`.
- Re-added only the two files still absent from `master`.

## Files added by this PR

- `EAFIX_auth_docs/atonic to canonical crosswalk.csv`
- `EAFIX_auth_docs/Q-R_atonic to canonical crosswalk.txt`

## Notes

No deletions or overwrites are intended.