### PR TITLE
Standardize EAFIX_auth_docs filenames

### DIFF
--- a/EAFIX_auth_docs/Claude_gen_atomic_module_catalog_vNext.json
+++ b/EAFIX_auth_docs/Claude_gen_atomic_module_catalog_vNext.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1.0.0",
+  "document_type": "atomic_module_catalog_vNext",
+  "catalog_id": "eafix.atomic_module_catalog.vNext",
+  "catalog_name": "EAFIX Atomic Module Catalog — vNext (Locked Pass 1)",
+  "version": "1.0.0",
+  "generated_at_utc": "2026-06-06T13:45:36.917486+00:00",
+  "authority_policy": "generated_from_canonical_sources",
+  "lock_state": "LOCKED_PASS_1",
+  "lock_scope": "34 well-supported atomic modules (Python pipeline + shared kernel + UI/gateway). EA-side Systems A-G deferred to Pass 2.",
+  "module_count": 34,
+  "generated_from_documents": [
+    "module_catalog.json",
+    "updated_trading_process_aligned.json",
+    "process_step_catalog.json",
+    "EAFIX-Modular___End-to-End_Module_Map.txt",
+    "EAFIX_module_reconciliation_worksheet.csv",
+    "ui_catalog.json",
+    "eafix_services_ai_reference_20260510.json",
+    "MT4_Python_communication_channels.txt"
+  ],
+  "lock_decisions": [
+    "26 process-bound canonical modules retained (1:1 with steps S01-S26).",
+    "F1_FLOW_ORCHESTRATOR renamed to F4_FLOW_ORCHESTRATOR to clear PREFIX_COLLISION_F1; layer set cross_cutting.",
+    "R1_RISK_EVALUATOR narrowed to the approval decision; correlation guard promoted to R3_CORRELATION_GUARD (emits RiskGuardResult, consumed by R1).",
+    "KIND_MISMATCH resolved: adopted domain-specific module_kind (COMPUTE/SIGNAL/RISK/OMS/REENTRY) over generic PIPELINE_STAGE_MODULE.",
+    "STALE_CSV_SYMBOL resolved: O2_OMS / O3_PNL_CLASSIFIER recorded as legacy_aliases.",
+    "4 UI/gateway modules promoted (U1-U4); individual tabs/panels remain internal.",
+    "P2_REPORTER promoted from service inventory (absent from prior pipeline catalog).",
+    "SK1_PLUGIN_INTERFACE + SK2_IDEMPOTENCY promoted to shared-kernel; SHARED_LIBS umbrella demoted to domain group; reentry helper folds into E-series; positioning deferred to Pass 2.",
+    "New numeric IDs assigned ...027-...034 (below reserved ...099)."
+  ],
+  "modules": []
+}

--- a/EAFIX_auth_docs/Simple_Explanation_of_the_Entire_EAFIX___HUEY_P_System.txt
+++ b/EAFIX_auth_docs/Simple_Explanation_of_the_Entire_EAFIX___HUEY_P_System.txt
@@ -1,0 +1,642 @@
+
+Below is the actual breakdown in plain language directly in the response so you can read it on your phone without downloading anything.
+The explanation is based primarily on:
+	•	module_catalog.json and its module descriptions  
+	•	MT4 authoritative reference for ai.json  
+	•	MT4_Python communication channels.txt summary  
+ 
+⸻
+ 
+Simple Explanation of the Entire EAFIX / HUEY_P System
+Big Picture
+This entire system is basically:
+A giant automated trading factory.
+The system watches the market, studies conditions, decides whether a trade is safe, sends orders to MT4, tracks the trade, and then decides what to do next.
+Think of it like:
+Real World Analogy — Amazon Warehouse + Air Traffic Control + Military Command Center
+Imagine:
+	•	Economic news = weather reports
+	•	Market prices = live highway traffic
+	•	Trading signals = delivery opportunities
+	•	Risk engine = safety department
+	•	MT4 = the delivery truck driver
+	•	OMS = package tracking system
+	•	Reentry system = deciding whether to send another truck
+Every module is one department in the company.
+ 
+⸻
+ 
+The System Is Divided Into Departments
+Layer	Purpose
+Foundation	Keeps system alive
+Data Ingest	Collects outside information
+Compute Layer	Turns raw data into intelligence
+Signal Layer	Decides whether a trade should happen
+Risk Layer	Decides if trade is safe
+Order Layer	Sends orders
+MT4 Bridge	Talks to MetaTrader
+OMS	Tracks orders and trades
+Reentry	Decides whether to trade again
+Health/Monitoring	Watches whole system
+ 
+⸻
+ 
+FOUNDATION MODULES
+These are the "electricity and plumbing" of the system.
+ 
+⸻
+ 
+F1_CONFIG_PREFERENCES
+"Configuration Service"
+Simple Meaning
+This is the system's rulebook.
+It loads all settings:
+	•	broker rules
+	•	lot sizes
+	•	risk %
+	•	trading hours
+	•	enabled strategies
+	•	API addresses
+	•	timeouts
+Everything else depends on this.
+Real World Example
+Like loading the flight plan before a plane takes off.
+Without this:
+	•	nobody knows where to go
+	•	nobody knows the rules
+	•	chaos happens
+ 
+⸻
+ 
+F3_CLOCK_SCHEDULER
+"System Heartbeat"
+Simple Meaning
+This module acts like a timer.
+Every few seconds or minutes it tells the system:
+"Time to check market." "Time to update calendar." "Time to evaluate trades."
+Real World Example
+Like the conductor in an orchestra.
+Everybody moves when the conductor signals.
+ 
+⸻
+ 
+F2_EVENT_LOG
+"Black Box Flight Recorder"
+Simple Meaning
+Records everything.
+Every event:
+	•	price update
+	•	signal
+	•	order
+	•	rejection
+	•	trade close
+	•	error
+gets stored permanently.
+Real World Example
+Like an airplane black box recorder.
+If something goes wrong later:
+	•	investigators can replay everything.
+ 
+⸻
+ 
+DATA INGEST LAYER
+This layer collects outside information.
+ 
+⸻
+ 
+D1_MARKET_FEED_ADAPTER
+"Market Data Collector"
+Simple Meaning
+Collects live prices from MT4.
+Example:
+	•	EURUSD price
+	•	GBPJPY price
+	•	spread
+	•	bid/ask
+Real World Example
+Like a weather station constantly measuring temperature and wind.
+ 
+⸻
+ 
+D2_CALENDAR_SOURCE_ADAPTER
+"Economic News Collector"
+Simple Meaning
+Collects economic calendar events:
+	•	CPI
+	•	NFP
+	•	interest rates
+	•	FOMC
+	•	unemployment
+Real World Example
+Like a newsroom gathering breaking news.
+ 
+⸻
+ 
+D3_CALENDAR_NORMALIZER
+"Translator"
+Simple Meaning
+Different websites format data differently.
+This module standardizes everything:
+	•	UTC timestamps
+	•	impact ratings
+	•	naming conventions
+Real World Example
+Like translating many languages into one common language.
+ 
+⸻
+ 
+D4_CALENDAR_TRIGGER_BUILDER
+"News Alert Engine"
+Simple Meaning
+Creates warnings before important events.
+Example:
+	•	1 hour before NFP
+	•	10 minutes before CPI
+The trading system may reduce risk or stop trading.
+Real World Example
+Like tornado warning alerts before a storm arrives.
+ 
+⸻
+ 
+COMPUTE / FEATURE LAYER
+This layer turns raw market data into usable intelligence.
+ 
+⸻
+ 
+C1_BAR_BUILDER
+"Candle Builder"
+Simple Meaning
+Turns tick-by-tick prices into candles:
+	•	1 minute candles
+	•	5 minute candles
+	•	hourly candles
+OHLC bars:
+	•	open
+	•	high
+	•	low
+	•	close
+Real World Example
+Like summarizing thousands of heartbeats into one medical chart.
+ 
+⸻
+ 
+C2_INDICATOR_ENGINE
+"Technical Analysis Computer"
+Simple Meaning
+Calculates indicators:
+	•	RSI
+	•	moving averages
+	•	ATR
+	•	Bollinger Bands
+	•	MACD
+Real World Example
+Like medical lab equipment analyzing blood samples.
+ 
+⸻
+ 
+C3_FEATURE_PACKAGER
+"Intelligence Folder Builder"
+Simple Meaning
+Combines:
+	•	indicators
+	•	market data
+	•	calendar warnings
+	•	positions
+	•	trend data
+into one clean package.
+This package is called:
+FeatureFrame
+Real World Example
+Like building a military intelligence briefing packet before making decisions.
+ 
+⸻
+ 
+SIGNAL LAYER
+This layer decides whether a trade opportunity exists.
+ 
+⸻
+ 
+S1_SIGNAL_ENGINE
+"Trade Brain"
+Simple Meaning
+This is the strategy itself.
+It looks at the FeatureFrame and decides:
+	•	BUY
+	•	SELL
+	•	DO NOTHING
+Important
+This module:
+	•	DOES NOT place trades
+	•	DOES NOT size trades
+	•	DOES NOT handle brokers
+It ONLY decides direction.
+Real World Example
+Like a chess grandmaster deciding:
+"This is the right move."
+ 
+⸻
+ 
+S2_INTENT_BUILDER
+"Trade Request Builder"
+Simple Meaning
+Turns the signal into an official trade request.
+Adds:
+	•	reasons
+	•	metadata
+	•	correlation IDs
+	•	strategy references
+Real World Example
+Like filling out a mission authorization form.
+ 
+⸻
+ 
+RISK LAYER
+This is the safety department.
+ 
+⸻
+ 
+R1_RISK_EVALUATOR
+"Risk Manager"
+Simple Meaning
+Decides whether the trade is safe.
+Checks:
+	•	account balance
+	•	drawdown
+	•	exposure
+	•	lot size
+	•	volatility
+	•	daily loss limits
+Can:
+	•	APPROVE
+	•	REJECT
+Real World Example
+Like a bank loan officer approving or denying a loan.
+ 
+⸻
+ 
+R2_ORDER_INTENT_COMPILER
+"Final Order Builder"
+Simple Meaning
+Converts approved trade into actual executable order instructions.
+Adds:
+	•	ticket IDs
+	•	idempotency keys
+	•	broker formatting
+Real World Example
+Like converting architectural drawings into exact construction blueprints.
+ 
+⸻
+ 
+ORDER ROUTING
+ 
+⸻
+ 
+O1_ORDER_ROUTER
+"Traffic Controller"
+Simple Meaning
+Decides where order goes.
+Could route:
+	•	Broker A
+	•	Broker B
+	•	MT4 terminal
+	•	paper trading
+	•	simulator
+Real World Example
+Like airport air traffic control routing planes to correct runway.
+ 
+⸻
+ 
+MT4 BRIDGE LAYER
+This is where Python talks to MetaTrader 4.
+Very important section.
+ 
+⸻
+ 
+B1_MT4_ADAPTER_TRANSPORT
+"Translator Between Python and MT4"
+Simple Meaning
+Packages orders into formats MT4 can understand.
+Handles:
+	•	serialization
+	•	transport
+	•	retries
+	•	atomic writes
+	•	hashes
+	•	delivery guarantees
+Real World Example
+Like a shipping department packaging products safely before delivery.
+ 
+⸻
+ 
+B2_MT4_EA_EXECUTOR
+"MT4 Soldier"
+Simple Meaning
+This is the actual MT4 Expert Advisor.
+It:
+	•	receives orders
+	•	executes trades
+	•	reports fills
+	•	reports failures
+Important Rule
+According to the authoritative MT4 reference:
+	•	MT4 terminal MUST remain open
+	•	EAs only run on desktop terminal
+	•	Web terminal cannot run EAs  
+Real World Example
+Like the actual truck driver delivering packages.
+ 
+⸻
+ 
+B3_EXEC_EVENT_NORMALIZER
+"Broker Translator"
+Simple Meaning
+Broker responses are messy.
+This module converts them into clean standardized reports.
+Example:
+	•	partial fills
+	•	rejections
+	•	closes
+	•	slippage
+Real World Example
+Like converting handwritten police notes into standardized reports.
+ 
+⸻
+ 
+OMS LAYER (ORDER MANAGEMENT SYSTEM)
+This tracks all orders and positions.
+ 
+⸻
+ 
+O2_OMS_STATE_MACHINE
+"Trade Tracking System"
+Simple Meaning
+Tracks:
+	•	open trades
+	•	closed trades
+	•	pending orders
+	•	fills
+	•	partial fills
+	•	cancellations
+Maintains official state.
+Real World Example
+Like FedEx package tracking.
+ 
+⸻
+ 
+O3_TRADE_CLOSE_CLASSIFIER
+"Outcome Analyzer"
+Simple Meaning
+When trade closes:
+	•	calculates profit/loss
+	•	determines why trade closed
+	•	categorizes result
+Real World Example
+Like a sports analyst reviewing the outcome of a game.
+ 
+⸻
+ 
+REENTRY ENGINE
+This is advanced logic.
+The system decides whether to trade again after a loss or win.
+ 
+⸻
+ 
+E1_OUTCOME_BUCKETIZER
+"Trade Result Categorizer"
+Simple Meaning
+Places outcomes into buckets:
+	•	BIG WIN
+	•	SMALL WIN
+	•	STOP LOSS
+	•	NEWS LOSS
+	•	BREAKEVEN
+Real World Example
+Like sorting insurance claims into categories.
+ 
+⸻
+ 
+E2_PROXIMITY_EVALUATOR
+"Danger Detector"
+Simple Meaning
+Checks whether dangerous events are near:
+	•	news releases
+	•	volatility spikes
+	•	market open/close
+Real World Example
+Like checking how close a hurricane is before launching a boat.
+ 
+⸻
+ 
+E3_MATRIX_LOOKUP
+"Decision Matrix"
+Simple Meaning
+Uses giant rule tables to decide:
+	•	reentered
+	•	wait
+	•	reduce size
+	•	suppress trading
+Real World Example
+Like military rules of engagement tables.
+ 
+⸻
+ 
+E4_REENTRY_INTENT_BUILDER
+"Second Attempt Builder"
+Simple Meaning
+Builds new trade intents after previous trade outcome.
+Also prevents:
+	•	infinite loops
+	•	revenge trading
+	•	runaway chains
+Real World Example
+Like deciding whether to send reinforcements after a battle.
+ 
+⸻
+ 
+HEALTH & MONITORING
+ 
+⸻
+ 
+P1_HEALTH_AGGREGATOR
+"System Doctor"
+Simple Meaning
+Monitors entire platform:
+	•	services alive?
+	•	MT4 connected?
+	•	Redis working?
+	•	APIs responding?
+	•	scheduler alive?
+If unhealthy:
+	•	system may stop trading automatically.
+Real World Example
+Like a hospital ICU monitoring center.
+ 
+⸻
+ 
+HOW MT4 AND PYTHON TALK
+This is one of the most important concepts.
+The system uses MULTIPLE communication channels simultaneously.  
+ 
+⸻
+ 
+1. HTTP REST API
+Meaning
+MT4 sends HTTP requests to Python services.
+Example:
+	•	GET indicators
+	•	GET calendar
+	•	GET expiry zones
+Files
+MT4:
+	•	2299900003260118_ExpiryZones.mq4
+Python:
+	•	2099900129260118_expiry_service.py
+ 
+⸻
+ 
+2. DDE Feed
+Meaning
+MT4 streams live prices into Python.
+Python polls MT4 every 100ms.
+Real World Example
+Like a live stock ticker tape.
+ 
+⸻
+ 
+3. CSV Transport
+Meaning
+Systems exchange CSV files through watched folders.
+Real World Example
+Like office departments dropping paperwork into inbox trays.
+ 
+⸻
+ 
+4. JSONL Outbox
+Meaning
+Python writes signals into .jsonl files for MT4 to read.
+Real World Example
+Like leaving instructions in a mailbox.
+ 
+⸻
+ 
+5. Redis Pub/Sub
+Meaning
+Acts like the nervous system of Python services.
+Services broadcast messages to each other instantly.
+Topics include:
+	•	price feeds
+	•	order validation
+	•	execution results  
+Real World Example
+Like police radio channels.
+ 
+⸻
+ 
+OVERALL FLOW OF ENTIRE SYSTEM
+Complete Example
+ 
+⸻
+ 
+STEP 1
+MT4 sends live EURUSD prices.
+↓
+STEP 2
+Market adapter receives prices.
+↓
+STEP 3
+Bar Builder creates candles.
+↓
+STEP 4
+Indicator engine calculates RSI + EMA.
+↓
+STEP 5
+Calendar system detects upcoming NFP event.
+↓
+STEP 6
+Feature Packager combines:
+	•	RSI
+	•	EMA
+	•	volatility
+	•	news proximity
+	•	spread
+↓
+STEP 7
+Signal Engine decides:
+BUY EURUSD
+↓
+STEP 8
+Risk Engine checks:
+	•	too much exposure?
+	•	daily loss limit?
+	•	volatility too high?
+↓
+STEP 9
+If approved: Order Intent created.
+↓
+STEP 10
+Order routed to MT4.
+↓
+STEP 11
+MT4 EA executes trade.
+↓
+STEP 12
+Broker sends fill result.
+↓
+STEP 13
+OMS tracks position.
+↓
+STEP 14
+Trade closes.
+↓
+STEP 15
+Outcome classified.
+↓
+STEP 16
+Reentry system decides:
+	•	trade again
+	•	wait
+	•	suppress
+ 
+⸻
+ 
+MOST IMPORTANT ARCHITECTURAL PRINCIPLE
+The system intentionally separates responsibilities.
+Example:
+Module	ONLY Responsible For
+Signal Engine	Trade direction
+Risk Engine	Safety
+Router	Delivery
+MT4 EA	Execution
+OMS	Tracking
+This prevents:
+	•	hidden logic
+	•	inconsistent behavior
+	•	spaghetti code
+	•	duplicated functionality
+ 
+⸻
+ 
+Why The Architecture Is Advanced
+This is NOT a simple MT4 bot.
+It is designed more like:
+	•	institutional trading infrastructure
+	•	distributed systems
+	•	aviation-grade event pipelines
+	•	enterprise OMS systems
+It includes:
+	•	deterministic processing
+	•	idempotency
+	•	append-only logs
+	•	event sourcing
+	•	normalization layers
+	•	failure isolation
+	•	transport guarantees
+	•	replayability
+	•	modular decomposition
+All of that exists specifically to make:
+	•	debugging easier
+	•	auditing possible
+	•	behavior deterministic
+	•	AI development safer
+	•	scaling easier
+	•	failures survivable

--- a/EAFIX_auth_docs/atomic_module_decomposition_decisions.json
+++ b/EAFIX_auth_docs/atomic_module_decomposition_decisions.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "1.0.0",
+  "document_type": "atomic_module_decomposition_decisions",
+  "title": "EAFIX Atomic Module Decomposition — Candidate Inventory + Dispositions",
+  "generated_at_utc": "2026-06-06T04:25:10.478405Z",
+  "authority_policy": "generated_from_canonical_sources",
+  "method": "Seed from 26 process-bound canonical modules; extract candidates from submodules/key-functions, EA systems A-G, UI products, shared libs, and the service inventory; score atomicity (0-...",
+  "generated_from_documents": [
+    "module_catalog.json",
+    "updated_trading_process_aligned.json",
+    "process_step_catalog.json",
+    "EAFIX-Modular___End-to-End_Module_Map.txt",
+    "EAFIX_module_reconciliation_worksheet.csv",
+    "ui_catalog.json",
+    "eafix_services_ai_reference_20260510.json",
+    "atonic_to_canonical_crosswalk.csv",
+    "MT4_Python_communication_channels.txt"
+  ],
+  "disposition_counts": {
+    "CONVERT_TO_DOMAIN_GROUP": 1,
+    "DOMAIN_GROUP_ONLY": 1,
+    "KEEP_CANONICAL": 24,
+    "KEEP_CANONICAL_BUT_SPLIT": 1,
+    "KEEP_CANONICAL_RENAME": 1,
+    "MERGE_INTO_PARENT": 1,
+    "MOVE_TO_SHARED_KERNEL": 2,
+    "NEEDS_REVIEW": 12,
+    "PROMOTE_GATEWAY_MODULE": 1,
+    "PROMOTE_MQL4_INDICATOR_MODULE": 1,
+    "PROMOTE_SERVICE_MODULE": 1,
+    "PROMOTE_UI_MODULE": 2,
+    "PROMOTE_WORK_CELL": 1
+  },
+  "candidates": [
+    {
+      "candidate_id": "CANDIDATE-F1_CONFIG_PREFERENCES",
+      "candidate_name": "Configuration Service",
+      "origin_type": "canonical_module",
+      "source_parent": null,
+      "decision": "KEEP_CANONICAL",
+      "target_module_symbol": "F1_CONFIG_PREFERENCES",
+      "atomicity_score": 9,
+      "rationale": "1:1 process step (S01) with single declared input/output contract; numeric ID present; corroborated by catalog, aligned-process phases, and reconciliation worksheet.",
+      "source_evidence": [
+        "module_catalog.json",
+        "updated_trading_process_aligned.json",
+        "process_step_catalog.json"
+      ],
+      "review_flags": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Creates the canonical underscore-based filenames for three EAFIX project knowledge files.

## Files added on this branch

- `EAFIX_auth_docs/atomic_module_decomposition_decisions.json`
- `EAFIX_auth_docs/Claude_gen_atomic_module_catalog_vNext.json`
- `EAFIX_auth_docs/Simple_Explanation_of_the_Entire_EAFIX___HUEY_P_System.txt`

## Follow-up required after merge

This branch adds the canonical filenames but does not delete the old alias filenames. After merge, remove the old alias paths:

- `EAFIX_auth_docs/atomic module decomposition decisions.json`
- `EAFIX_auth_docs/Claude_gen_atomic module catalog vNext.json`
- `EAFIX_auth_docs/Simple Explanation of the Entire EAFIX : HUEY_P System.txt`