### PR TITLE
chore: trigger registry bootstrap

### DIFF
--- a/tools/registries/bootstrap-parts/trigger.txt
+++ b/tools/registries/bootstrap-parts/trigger.txt
@@ -1,0 +1,1 @@
+Trigger the one-time registry bootstrap workflow from a child pull request.


### PR DESCRIPTION
Closed without merge. This temporary child PR was used only to test whether GitHub Actions would run the one-time bootstrap from the feature branch. No workflow run was registered, confirming the repository-level Actions execution blocker.