### PR TITLE
chore: delete confirmed stale Copilot branches

### DIFF
--- a/.github/workflows/one-time-stale-branch-cleanup.yml
+++ b/.github/workflows/one-time-stale-branch-cleanup.yml
@@ -1,0 +1,40 @@
+name: One-time stale branch cleanup
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/one-time-stale-branch-cleanup.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  delete-stale-branches:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Delete approved stale branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branches=(
+            'copilot/analyze-and-describe-10-branches'
+            'copilot/copilotresolve-conflict-in-pr-29'
+            'copilot/eafix-registry-bootstrap-trigger'
+            'copilot/eafix-registry-system-v1'
+            'agent/delete-stale-copilot-branches'
+          )
+
+          for branch in "${branches[@]}"; do
+            if gh api "repos/${REPOSITORY}/git/ref/heads/${branch}" >/dev/null 2>&1; then
+              gh api --method DELETE "repos/${REPOSITORY}/git/refs/heads/${branch}"
+              echo "Deleted ${branch}"
+            else
+              echo "Already absent: ${branch}"
+            fi
+          done


### PR DESCRIPTION
## What changed

Adds a one-time administrative GitHub Actions workflow that deletes only the following verified stale branches:

- `copilot/analyze-and-describe-10-branches`
- `copilot/copilotresolve-conflict-in-pr-29`
- `copilot/eafix-registry-bootstrap-trigger`
- `copilot/eafix-registry-system-v1`
- `agent/delete-stale-copilot-branches`

## Verification performed

- The first two branches are zero commits ahead of `master`.
- The registry implementation was merged through PR #74.
- The bootstrap branch belonged to closed, intentionally unmerged test PR #75 and contains obsolete bootstrap payload files.
- No open pull request depends on these branches.

## Scope

This workflow performs branch-reference cleanup only. It does not alter application, registry, documentation, or generated artifact content. The one-time workflow will be removed from `master` after execution is verified.